### PR TITLE
Fix syntax error.

### DIFF
--- a/javascripts/camvas.js
+++ b/javascripts/camvas.js
@@ -82,7 +82,7 @@ function camvas(ctx, drawFunc) {
       // For some effects, you might want to know how much time is passed
       // since the last frame; that's why we pass along a Delta time `dt`
       // variable (expressed in milliseconds)
-      var dt = Date.now - last
+      var dt = Date.now() - last
       self.draw(self.video, dt)
       last = Date.now()
       requestAnimationFrame(loop) 


### PR DESCRIPTION
I tried to get the elapsed time, but it was `NaN`.

```
<script>
window.onload = function(){
  var ctx = document.getElementsByTagName('canvas')[0].getContext('2d')
  var draw = function(video, dt) {
    console.log(dt); // => NaN
    ctx.drawImage(video, 0, 0)
  }
  var myCamvas = new camvas(ctx, draw)
}
</script>
```

I fixed it for that.