### PR TITLE
Assign stream to srcObject directly

### DIFF
--- a/javascripts/camvas.js
+++ b/javascripts/camvas.js
@@ -66,7 +66,11 @@ function camvas(ctx, drawFunc) {
   getUserMedia({video: true}, function(stream) {
     // Yay, now our webcam input is treated as a normal video and
     // we can start having fun
-    self.video.src = window.URL.createObjectURL(stream)
+    try {
+      self.video.srcObject = stream;
+    } catch (error) {
+      self.video.src = URL.createObjectURL(stream);
+    }
     // Let's start drawing the canvas!
     self.update()
   }, function(err){


### PR DESCRIPTION
URL.createObjectURL for MediaStream is deprecated, no longer working in latest Firefox (63.0.3) and will be removed also in Chrome 71
(https://www.chromestatus.com/features/5618491470118912)